### PR TITLE
Feat/BAC-46-single/multiple-audio-listing-deletion

### DIFF
--- a/backend/app/emails.py
+++ b/backend/app/emails.py
@@ -20,11 +20,11 @@ conf = ConnectionConfig(
     MAIL_USERNAME = os.getenv('EMAIL'),
     MAIL_PASSWORD = os.getenv('PASS'),
     MAIL_FROM = os.getenv('EMAIL'),
-    MAIL_PORT = 465,
+    MAIL_PORT = 587,
     MAIL_SERVER = 'smtp.gmail.com',
-    MAIL_STARTTLS = False,
+    MAIL_STARTTLS = True,
     USE_CREDENTIALS = True,
-    MAIL_SSL_TLS= True,
+    MAIL_SSL_TLS= False,
     VALIDATE_CERTS = True
 )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -346,6 +346,6 @@ def delete_audios(audios: List[int] = Query(None), db: Session = Depends(get_db)
         if db_audio:
             db.delete(db_audio)
             db.commit()
-            delete_audios.append(db_audio.audio_path)
-    return {"message": "operation successful", "deleted audion(s)": delete_audios}
+            deleted_audios.append(db_audio.audio_path)
+    return {"message": "operation successful", "deleted audion(s)": deleted_audios}
             

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
-
-from fastapi import Depends, FastAPI, UploadFile, File, status, HTTPException, Form
+from typing import List
+from models import Audio
+from fastapi import Depends, FastAPI, UploadFile, File, status, HTTPException, Form, Query
 from fastapi_pagination import Page, paginate, Params
 from fastapi.middleware.cors import CORSMiddleware
 from routers.sentiment import sentiment
@@ -143,6 +144,7 @@ async def new_analyse(first_name: str = Form(), last_name: str = Form(), db: Ses
     db.add(db_agent)
     db.commit()
     db.refresh(db_agent)
+    
 
     try:
         contents = file.file.read()
@@ -278,13 +280,10 @@ def get_sentiment_result(id: int, db: Session = Depends(get_db)):
             detail="The analysis doesn't exist",
         )
     return analysis
-
-
 @app.get("/audios", summary = "get all audio uploads", response_model=list[schema.Audio], tags=['audios'])
 def read_audios(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
     audios = crud.get_audios(db, skip=skip, limit=limit)
     return audios
-
 
 @app.get('/audios/{audio_id}/sentiment')
 def read_sentiment(audio_id: int, db: Session = Depends(get_db), user: models.User = Depends(get_active_user)):
@@ -338,3 +337,15 @@ async def my_profile (db: Session = Depends(get_db), user: models.User = Depends
 if __name__ == "__main__":
     main()
 
+#delete single and multiple audios
+@app.delete("/audios/delete")
+def delete_audios(audios: List[int] = Query(None), db: Session = Depends(get_db), user: models.User = Depends(get_active_user)):
+    deleted_audios = []
+    for audio_id in audios:
+        db_audio = crud.get_audio(db, audio_id=audio_id)
+        if db_audio:
+            db.delete(db_audio)
+            db.commit()
+            delete_audios.append(db_audio.audio_path)
+    return {"message": "operation successful", "deleted audion(s)": delete_audios}
+            


### PR DESCRIPTION
Created an endpoint that enables single or multiple deletion of audios/jobs in the audio listing page. This endpoint takes an array of integers(audio ids) and deletes audios that match any of the id.

Linear ticket: https://linear.app/team-brainbox/issue/BAC-46/heed-singlemultiple-audio-listing-deletion-weight